### PR TITLE
Правит ошибку expires даты в куках

### DIFF
--- a/source/components/cookies/js/cookie-consent-checker.js
+++ b/source/components/cookies/js/cookie-consent-checker.js
@@ -17,7 +17,7 @@ export const cookieConsentChecker = () => {
       evt.preventDefault();
       const cookieDuration = +cookieElement.dataset.cookiesDuration || BASE_DURATION;
       cookieElement.classList.remove('is-active');
-      consentCookie.set('has_cookie_consent', 'yes', cookieDuration);
+      consentCookie.set('yes', cookieDuration);
     });
   }
 };

--- a/source/html/cookies.html
+++ b/source/html/cookies.html
@@ -40,7 +40,7 @@
           <div class="component__code-snippet">
             <pre>
               <code>
-                &lt;div class="cookies is-active" data-cookies data-duration="30"&gt;
+                &lt;div class="cookies is-active" data-cookies data-cookies-duration="30"&gt;
                   &lt;div&gt; class="cookies__text"&gt;
                     &lt;span&gt;Мы используем куки&lt;/span&gt;
                   &lt;/div&gt;


### PR DESCRIPTION
Обнаружил ошибку в передаче даты истечения принятой куки. 
Метод consentCookie.set() должен принимать 2 аргумента, а не 3. 